### PR TITLE
`useFragment` を `getFragmentData` に改名する

### DIFF
--- a/frontend/app-urql/src/components/Band/MemberItem/index.tsx
+++ b/frontend/app-urql/src/components/Band/MemberItem/index.tsx
@@ -1,4 +1,4 @@
-import { useFragment, type FragmentType } from '@learn-graphql/api/src/gql/fragment-masking';
+import { getFragmentData, type FragmentType } from '@learn-graphql/api/src/gql/fragment-masking';
 import { BandMemberFragmentDoc } from '@learn-graphql/api/src/gql/graphql';
 import { type CSSProperties } from 'react';
 
@@ -7,7 +7,7 @@ type Props = {
 };
 
 export const MemberItem = ({ member }: Props) => {
-  const { name, instrument } = useFragment(BandMemberFragmentDoc, member);
+  const { name, instrument } = getFragmentData(BandMemberFragmentDoc, member);
 
   return (
     <div style={styleBase}>

--- a/packages/api/bin/codegen.ts
+++ b/packages/api/bin/codegen.ts
@@ -14,6 +14,14 @@ const config: CodegenConfig = {
   generates: {
     'src/gql/': {
       preset: 'client',
+      presetConfig: {
+        fragmentMasking: {
+          // `useFragment` を `getFragmentData` に名称変更する。
+          // デフォルトの名称だと React がカスタムフックと誤解して用法が大幅に制限されるため。
+          // @see: https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#the-usefragment-helper
+          unmaskFunctionName: 'getFragmentData',
+        },
+      },
       config: {
         enumsAsTypes: true,
         strictScalars: true,


### PR DESCRIPTION
## :memo: 変更情報

### なぜこれをやるのか

<!-- 必須 -->
<!-- なぜこの変更をするのか、課題は何か、これによってどう解決されるのかなど、この変更を行った理由を記述 -->

`useFragment` では React コアエンジンがカスタムフックと誤解して用法が大幅に制限されてしまう（ `useFragment` は React フックではない）。

### 何を変更したのか

<!-- 必須 -->
<!-- この作業ブランチで何を変更をしたかの概要を記述 -->

unmask function 名をデフォルト値である `useFragment` から `getFragmentData` に変更した。

### 技術的にはどこがポイントか

<!-- 任意: やむを得ない事情が無い限り記述すること。 -->
<!-- レビュワーに伝わるように技術的視線での変更概要説明 -->

graphql-codegen の設定ファイルを修正するだけで OK。公式ドキュメントでも紹介されている。

### どこまで動作確認したか

<!-- 任意: やむを得ない事情が無い限り記述すること。 -->
<!-- この作業ブランチの動作確認として何をどこで・確認したかを記述 -->

### 備考

<!-- 任意 -->
<!-- 完了の定義以外で確認したこと、追加したライブラリの使い方など、補足となる情報を記述 -->

## :classical_building: 参考文献

- [client-preset – GraphQL Code Generator](https://the-guild.dev/graphql/codegen/plugins/presets/preset-client#the-usefragment-helper)

